### PR TITLE
Delete iris/data/setup_package.py file from iris branch

### DIFF
--- a/sunkit_instruments/iris/data/setup_package.py
+++ b/sunkit_instruments/iris/data/setup_package.py
@@ -1,3 +1,0 @@
-def get_package_data():
-    return {'sunkit_instruments.iris.data': ['irispyrc'],
-            'sunkit_instruments.iris.data.test': ['*.*', '*/*.*']}


### PR DESCRIPTION
Fixes #15

To get rid of the `iris/data/setup_package.py` file from the `iris` branch in its entirety now that we are no longer following the old template. 