### PR TITLE
Test with `sunpy==5.1.0rc1`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ setup_requires =
   setuptools_scm
 install_requires =
   scipy
-  sunpy[net,timeseries]>=4.0.0
+  sunpy[net,timeseries]==5.1.0rc1
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
**DO NOT MERGE**

This tests the package against the sunpy release candidate for 5.1.0rc1