### PR TITLE
Do not apply marks on fixtures

### DIFF
--- a/sunkit_instruments/fermi/tests/test_fermi.py
+++ b/sunkit_instruments/fermi/tests/test_fermi.py
@@ -15,7 +15,6 @@ def test_download_weekly_pointing_file():
     assert afile.endswith(".fits")
 
 
-@pytest.mark.remote_data
 @pytest.fixture
 def pointing_file():
     # set a test date

--- a/sunkit_instruments/suvi/tests/conftest.py
+++ b/sunkit_instruments/suvi/tests/conftest.py
@@ -5,7 +5,6 @@ from parfive import Downloader
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.remote_data
 def L1B_FITS():
     downloader = Downloader()
     url = "https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/goes16/l1b/suvi-l1b-fe171/2021/12/31/OR_SUVI-L1b-Fe171_G16_s20213650006108_e20213650006118_c20213650006321.fits.gz"
@@ -16,7 +15,6 @@ def L1B_FITS():
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.remote_data
 def L1B_NC():
     downloader = Downloader()
     url = "https://noaa-goes16.s3.amazonaws.com/SUVI-L1b-Fe171/2021/365/00/OR_SUVI-L1b-Fe171_G16_s20213650022109_e20213650022119_c20213650022323.nc"
@@ -27,7 +25,6 @@ def L1B_NC():
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.remote_data
 def L2_COMPOSITE():
     downloader = Downloader()
     url = "https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/goes16/l2/data/suvi-l2-ci171/2021/12/31/dr_suvi-l2-ci171_g16_s20211231T000800Z_e20211231T001200Z_v1-0-1.fits"


### PR DESCRIPTION
[Applying marks on fixtures is deprecated in pytest since v7.4](https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function). This PR removes all the remote data marks on fixtures.