### PR TITLE
Added warning to Fermi detector angle calculation code, for when time returned is different from time requested

### DIFF
--- a/changelog/128.bugfix.rst
+++ b/changelog/128.bugfix.rst
@@ -1,0 +1,5 @@
+In the ``fermi``, the function ``get_detector_sun_angles_for_time`` returns the angle with respect to the Sun of each Fermi/GBM detector.
+However, these files contain gaps due to the South Atlantic Anomaly.
+If the time requested falls in one of these gaps, the code will return the detector angles for the next available time.
+This can be several minutes different from the time requested.
+Now, a warning to the user will be raised if the time returned by the code is more than 1 minute different from the time requested (1 minute is the nominal cadence of the spacecraft weekly file), and explains that this is likely due to a South Atlantic Anomaly encounter.

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated. Use packaging.version instead:DeprecationWarning
     ignore:Unknown units for CHANNEL:sunpy.util.exceptions.SunpyUserWarning
     ignore:.*is deprecated and slated for removal in Python 3:DeprecationWarning
-    ignore:Something went wrong:DeprecationWarning
+    ignore:.*Something went wrong.*:DeprecationWarning
 
 [isort]
 line_length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated. Use packaging.version instead:DeprecationWarning
     ignore:Unknown units for CHANNEL:sunpy.util.exceptions.SunpyUserWarning
     ignore:.*is deprecated and slated for removal in Python 3:DeprecationWarning
-    ignore:.*Something went wrong.*:DeprecationWarning
+    ignore:.*Something went wrong.*
 
 [isort]
 line_length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ filterwarnings =
     ignore:distutils Version classes are deprecated. Use packaging.version instead:DeprecationWarning
     ignore:Unknown units for CHANNEL:sunpy.util.exceptions.SunpyUserWarning
     ignore:.*is deprecated and slated for removal in Python 3:DeprecationWarning
+    ignore:Something went wrong:DeprecationWarning
 
 [isort]
 line_length = 110

--- a/sunkit_instruments/fermi/fermi.py
+++ b/sunkit_instruments/fermi/fermi.py
@@ -19,6 +19,7 @@ from sunpy.coordinates import sun
 from sunpy.time import TimeRange, parse_time
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
+from sunpy.util.exceptions import warn_user
 
 __all__ = [
     "download_weekly_pointing_file",
@@ -116,6 +117,18 @@ def get_detector_sun_angles_for_time(time, file):
 
     time = parse_time(time)
     scx, scz, tt = get_scx_scz_at_time(time, file)
+
+    # Fermi LAT spacecraft files have gaps due to SAA. If the requested time falls
+    # in one of these gaps, the time and angles returned will be the next available
+    # time in the file. This may be several minutes different from the request.   
+    # If the returned time is > 60s different from the time requested, raise a warning.
+    if np.abs((tt - time).sec) > 60.:
+        warn_user("The time requested is missing from the Fermi spacecraft file. "
+                      "The requested time probably occurs during the South Atlantic Anomaly. "
+                      f"Returning detector angles for the next available time: {tt}"
+                      )
+        
+    
     # retrieve the detector angle information in spacecraft coordinates
     detectors = nai_detector_angles()
 

--- a/sunkit_instruments/fermi/fermi.py
+++ b/sunkit_instruments/fermi/fermi.py
@@ -120,15 +120,15 @@ def get_detector_sun_angles_for_time(time, file):
 
     # Fermi LAT spacecraft files have gaps due to SAA. If the requested time falls
     # in one of these gaps, the time and angles returned will be the next available
-    # time in the file. This may be several minutes different from the request.   
+    # time in the file. This may be several minutes different from the request.
     # If the returned time is > 60s different from the time requested, raise a warning.
-    if np.abs((tt - time).sec) > 60.:
-        warn_user("The time requested is missing from the Fermi spacecraft file. "
-                      "The requested time probably occurs during the South Atlantic Anomaly. "
-                      f"Returning detector angles for the next available time: {tt}"
-                      )
-        
-    
+    if np.abs((tt - time).sec) > 60.0:
+        warn_user(
+            "The time requested is missing from the Fermi spacecraft file. "
+            "The requested time probably occurs during the South Atlantic Anomaly. "
+            f"Returning detector angles for the next available time: {tt}"
+        )
+
     # retrieve the detector angle information in spacecraft coordinates
     detectors = nai_detector_angles()
 


### PR DESCRIPTION
In the `fermi` module of `sunkit-instruments`, the code `get_detector_sun_angles_for_time` returns the angle with respect to the Sun of each Fermi/GBM detector. This is done by reading in a Fermi spacecraft weekly file.

However, these files contain gaps due to the South Atlantic Anomaly. If the time requested falls in one of these gaps, the code will return the detector angles for the next available time. This can be several minutes different from the time requested. Currently, the code does not provide any indication that this has happened.

This PR adds a warning to the user if the time returned by the code is more than 1 minute different from the time requested (1 minute is the nominal cadence of the spacecraft weekly file), and explains that this is likely due to a South Atlantic Anomaly encounter.
