### PR TITLE
Fixing Fermi plot_detector_sun_angles

### DIFF
--- a/changelog/130.bugfix.rst
+++ b/changelog/130.bugfix.rst
@@ -1,0 +1,1 @@
+The function ``plot_detector_sun_angles`` was broken, due to the formatting of the time axis.

--- a/sunkit_instruments/fermi/fermi.py
+++ b/sunkit_instruments/fermi/fermi.py
@@ -226,12 +226,17 @@ def plot_detector_sun_angles(angles):
         `~sunkit_instruments.fermi.get_detector_separation_angles` function.
     """
 
+    #reformat the time array so we can plot it
+    angle_times = []
+    for t in angles['time']:
+        angle_times.append(t.datetime)
+    
     # make a plot showing the angles vs time
-    figure = plt.figure(1)
+    figure = plt.figure(1, figsize=(12,6), layout = 'constrained')
     for n in angles.keys():
         if not n == "time":
             plt.plot(
-                angles["time"],
+                angle_times,
                 angles[n].value,
                 label="{lab} ({val})".format(
                     lab=n, val=str(np.mean(angles[n].value))[0:5]
@@ -239,9 +244,9 @@ def plot_detector_sun_angles(angles):
             )
     plt.ylim(180, 0)
     plt.ylabel("angle (degrees)")
-    plt.xlabel("Start time: " + angles["time"][0].isoformat())
+    plt.xlabel("Start time: " + angle_times[0].isoformat())
     plt.title("Detector pointing angle from Sun")
-    plt.legend(fontsize=10)
+    figure.legend(fontsize=10, loc ='outside center right')
     figure.autofmt_xdate()
     plt.show()
 

--- a/sunkit_instruments/fermi/fermi.py
+++ b/sunkit_instruments/fermi/fermi.py
@@ -225,14 +225,12 @@ def plot_detector_sun_angles(angles):
         function of time. Obtained from the
         `~sunkit_instruments.fermi.get_detector_separation_angles` function.
     """
-
-    #reformat the time array so we can plot it
+    # Reformat the time array so we can plot it
     angle_times = []
-    for t in angles['time']:
+    for t in angles["time"]:
         angle_times.append(t.datetime)
-    
-    # make a plot showing the angles vs time
-    figure = plt.figure(1, figsize=(12,6), layout = 'constrained')
+    # Make a plot showing the angles vs time
+    figure = plt.figure(1, figsize=(12, 6), layout="constrained")
     for n in angles.keys():
         if not n == "time":
             plt.plot(
@@ -246,7 +244,7 @@ def plot_detector_sun_angles(angles):
     plt.ylabel("angle (degrees)")
     plt.xlabel("Start time: " + angle_times[0].isoformat())
     plt.title("Detector pointing angle from Sun")
-    figure.legend(fontsize=10, loc ='outside center right')
+    figure.legend(fontsize=10, loc="outside center right")
     figure.autofmt_xdate()
     plt.show()
 


### PR DESCRIPTION
The function `plot_detector_sun_angles` was broken, due to the formatting of the time axis. This was reported in #71.

This PR proposes a fix by reformatting the time axis as datetimes, which matplotlib accepts. Also tidied up the location of the legend to be outside the plotting area.

Fixes #71 