### PR TITLE
Attempt to add  GOES flare detection algo

### DIFF
--- a/changelog/210.feature.rst
+++ b/changelog/210.feature.rst
@@ -1,1 +1,1 @@
-Add a generic "GOES Flare Detection"  like algorithm and a specific GOES version. Additonlly add and example gallery comparing the restults on 1 sec, 1min average data to eacth other and HEK.
+Add a generic "GOES flare detection"-like algorithm and a GOES-specific wrapper. Additionally, add an example gallery comparing results from 1 s and 1 min averaged data against each other and the HEK.

--- a/changelog/210.feature.rst
+++ b/changelog/210.feature.rst
@@ -1,0 +1,1 @@
+Add a generic "GOES Flare Detection"  like algorithm and a specific GOES version. Additonlly add and example gallery comparing the restults on 1 sec, 1min average data to eacth other and HEK.

--- a/examples/compare_goes_flare_detection.py
+++ b/examples/compare_goes_flare_detection.py
@@ -338,16 +338,22 @@ print("Flares reported in the official GOES event list (from the HEK):", len(hek
 ###############################################################################
 # Quiet period
 # ------------
-# Now let's set up a quiet period too, during solar minimum, where the
-# largest flare is only A-class. GOES-16 was still the primary satellite in
-# May 2020, but its secondary at the time was GOES-17 rather than GOES-18.
-# Since we're now looking for much weaker events, we also lower ``min_class``
-# and ``flux_threshold`` (the quiet-Sun background floor used to detect a
-# rise at all) from the B1.0 defaults down to A1.0.
+# Now let's set up a quiet period too, during solar minimum. May 2020 was
+# otherwise extremely quiet, but NOAA AR 12765/12766, one of the first
+# flaring active regions of Solar Cycle 25, produced a short burst of
+# activity (including an M1.1, the largest flare of the month) between
+# 2020-05-27 and 2020-05-29, so we focus there. GOES-16 was still the primary
+# satellite in May 2020, but its secondary at the time was GOES-17 rather
+# than GOES-18. Since we're now looking for much weaker events than the
+# active period above, we also lower ``min_class`` and ``flux_threshold``
+# (the quiet-Sun background floor used to detect a rise at all) from the
+# B1.0 defaults down to A1.0.
 #
 # (some of the extra events will dispear if use the extended info in the 1min avg files)
 
-tr_quiet = a.Time("2020-05-01 00:00", "2020-05-31 23:59")
+tr_quiet = a.Time("2020-05-26 00:00", "2020-05-31 23:59")
+# if offline run for entire month or longer
+# tr_quiet = a.Time("2020-05-01 00:00", "2020-05-31 23:59")
 
 merged_1s_quiet, merged_1min_quiet = fetch_merged_fluxes(tr_quiet, satellites=(16, 17))
 

--- a/examples/compare_goes_flare_detection.py
+++ b/examples/compare_goes_flare_detection.py
@@ -1,7 +1,7 @@
 """
-=======================================================
+========================================================
 GOES flare detection comparison between 1s, 1min and HEK
-=======================================================
+========================================================
 
 This example shows how to use `sunkit_instruments` to detect flares in
 GOES-XRS data, compares the results between the high-cadence (1-second)

--- a/examples/compare_goes_flare_detection_cadence.py
+++ b/examples/compare_goes_flare_detection_cadence.py
@@ -1,6 +1,6 @@
 """
 =======================================================
-GOES flare detection comprison between 1s, 1min and HEK
+GOES flare detection comparison between 1s, 1min and HEK
 =======================================================
 
 This example shows how to use `sunkit_instruments` to detect flares in

--- a/examples/compare_goes_flare_detection_cadence.py
+++ b/examples/compare_goes_flare_detection_cadence.py
@@ -1,0 +1,482 @@
+"""
+=======================================================
+GOES flare detection comprison between 1s, 1min and HEK
+=======================================================
+
+This example shows how to use `sunkit_instruments` to detect flares in
+GOES-XRS data, compares the results between the high-cadence (1-second)
+and 1-minute averaged data product, and compare both against the
+officially reported GOES flare list from the HEK.
+
+We will look at an active periodn in May 2024 with many large flare inxlucig
+an X-class and also a quiet period during solar minimum, in May 2020, where
+the largest flare in the windowis only A-class.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+import astropy.units as u
+from astropy.time import Time
+
+from sunpy import timeseries as ts
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+from sunpy.time import TimeRange
+
+from sunkit_instruments.goes_xrs import (
+    find_flares_naive,
+    find_goes_flares,
+    flareclass_to_flux,
+    get_goes_event_list,
+)
+
+###############################################################################
+# We start by searching for the GOES XRS data for our chosen time range. NOAA
+# provides two relevant data products: ``flx1s``, the high-cadence (1-second
+# for GOES-R satellites) flux, and ``avg1m``, the flux already averaged to a
+# 1-minute cadence.
+#
+# NOAA's own flare lists are built from a primary satellite, falling back to a
+# secondary satellite whenever the primary's data is flagged as poor quality
+# or missing, so we fetch both satellites here and do the same. Since we
+# repeat this fetch-and-merge step for two different time ranges (and pairs
+# of satellites) below, we wrap it in a function.
+
+
+def merge_primary_secondary(primary_df, secondary_df):
+    primary_good = primary_df[primary_df["xrsb_quality"] == 0]
+    all_minutes = pd.Index(primary_df.index.floor("min").unique())
+    good_minutes = pd.Index(primary_good.index.floor("min").unique())
+    bad_minutes = all_minutes.difference(good_minutes)
+
+    secondary_good = secondary_df[secondary_df["xrsb_quality"] == 0]
+    fill = secondary_good[secondary_good.index.floor("min").isin(bad_minutes)]
+
+    return pd.concat([primary_good["xrsb"], fill["xrsb"]]).sort_index()
+
+
+def fetch_merged_fluxes(tr, satellites):
+    query = Fido.search(
+        tr,
+        a.Instrument.xrs,
+        a.goes.SatelliteNumber(satellites[0]) | a.goes.SatelliteNumber(satellites[1]),
+        a.Resolution.flx1s | a.Resolution.avg1m,
+    )
+    files = Fido.fetch(query)
+
+    dataframes = {}
+    for satellite in satellites:
+        for resolution, key in [("avg1m", "1min"), ("flx1s", "1s")]:
+            matches = [f for f in files if f"g{satellite}_" in f and resolution in f]
+            dataframes[(satellite, key)] = ts.TimeSeries(matches, concatenate=True).to_dataframe()
+
+    merged_1min = merge_primary_secondary(
+        dataframes[(satellites[0], "1min")], dataframes[(satellites[1], "1min")]
+    )
+    merged_1s = merge_primary_secondary(
+        dataframes[(satellites[0], "1s")], dataframes[(satellites[1], "1s")]
+    )
+    return merged_1s, merged_1min
+
+
+###############################################################################
+# `~sunkit_instruments.goes_xrs.find_goes_flares` implements the NOAA SWPC
+# algorithm for detecting flares directly from a `~sunpy.timeseries.sources.XRSTimeSeries`,
+# and classifies each detection into a GOES class. It always rebins the input
+# onto a 1-minute cadence internally (matching the definition of the
+# algorithm), regardless of the native cadence of the data, so we expect both
+# timeseries to agree closely.
+
+
+def to_flares(series, min_class, **kwargs):
+    df = series.to_frame(name="xrsb")
+    goes_ts = ts.TimeSeries(df, {}, {"xrsb": u.W / u.m**2}, source="xrs")
+    return find_goes_flares(goes_ts, min_class=min_class, **kwargs)
+
+
+###############################################################################
+# To compare detections against the official list, we stack three panels,
+# one each for the 1-second detections, the 1-minute detections, and the
+# official HEK list. Each panel shows the same long channel flux (the merged
+# 1-minute data, for all three, so the panels are directly comparable) with
+# every flare shaded from its start to its end time, and its start, peak and
+# end times marked with different line styles. This is wrapped in a function
+# so we can reuse it below.
+
+vline_styles = {"start_time": ":", "peak_time": "-", "end_time": "--"}
+
+
+def plot_comparison(merged_1min, flares_1s, flares_1min, hek_events, title):
+    fig, axes = plt.subplots(3, 1, sharex=True, figsize=(10, 9))
+
+    panels = [
+        (axes[0], flares_1s, "1-second data", "tab:blue"),
+        (axes[1], flares_1min, "1-minute averaged data", "tab:orange"),
+        (axes[2], hek_events, "Official GOES event list (HEK)", "tab:red"),
+    ]
+
+    for ax, events, label, color in panels:
+        ax.plot(merged_1min.index, merged_1min.to_numpy(), color="black")
+        for event in events:
+            ax.axvspan(
+                event["start_time"].datetime, event["end_time"].datetime, color=color, alpha=0.2
+            )
+            for name, style in vline_styles.items():
+                ax.axvline(event[name].datetime, color=color, linestyle=style, alpha=0.8)
+        ax.set_yscale("log")
+        ax.set_ylabel(label)
+
+    for name, style in vline_styles.items():
+        axes[0].plot([], [], color="black", linestyle=style, label=name.replace("_", " "))
+    axes[0].legend(loc="upper right")
+
+    axes[-1].set_xlabel("Time")
+    fig.suptitle(title)
+    fig.autofmt_xdate()
+    plt.show()
+
+
+###############################################################################
+# Finally, we look at exactly which HEK events our algorithm failed to detect.
+# For each one, we plot the long channel flux in a window around its reported
+# peak time, together with its start/peak/end times, and shade in any of our
+# own detected events (from the 1-minute data) that overlap the same window.
+#
+# We also try to diagnose *why* each one was missed, by walking back from the
+# HEK peak along the monotonic rise leading up to it: if that rise is shorter
+# than ``min_rise_time`` it is annotated "too short", and if it doesn't reach
+# ``min_rise_ratio`` times its own starting flux it is annotated "not steep".
+# This is again wrapped in a function so we can reuse it below.
+
+MIN_RISE_TIME = 4  # minutes; matches find_flares' default min_rise_time
+MIN_RISE_RATIO = 1.4  # matches find_flares' default min_rise_ratio
+
+
+def diagnose_miss(series, peak_time):
+    flux = series.to_numpy()
+    idx = series.index.get_indexer([peak_time], method="nearest")[0]
+    j = idx
+    while j > 0 and flux[j - 1] < flux[j]:
+        j -= 1
+    duration = (series.index[idx] - series.index[j]) / pd.Timedelta(minutes=1)
+    ratio = flux[idx] / flux[j] if flux[j] > 0 else np.inf
+    if duration < MIN_RISE_TIME:
+        return "too short"
+    if ratio < MIN_RISE_RATIO:
+        return "too shollow"
+    return None
+
+
+def plot_missed_events(hek_events, flares_1min, merged_1min, window=pd.Timedelta(minutes=25)):
+    our_peaks = flares_1min["peak_time"].datetime64
+    missed_events = [
+        event
+        for event in hek_events
+        if np.abs((our_peaks - event["peak_time"].datetime64) / np.timedelta64(1, "m")).min() > 5
+    ]
+    print(f"{len(missed_events)} of {len(hek_events)} HEK events were not detected by our algorithm")
+
+    if not missed_events:
+        return missed_events
+
+    ncols = 4
+    nrows = int(np.ceil(len(missed_events) / ncols))
+    fig, axes = plt.subplots(nrows, ncols, figsize=(3.2 * ncols, 2.4 * nrows), squeeze=False)
+
+    for ax, event in zip(axes.flat, missed_events):
+        peak = pd.Timestamp(event["peak_time"].datetime)
+        lo, hi = peak - window, peak + window
+        segment = merged_1min.loc[lo:hi]
+        ax.plot(segment.index, segment.to_numpy(), color="black", lw=1)
+        ax.set_xlim(lo, hi)
+
+        for row in flares_1min:
+            if row["start_time"].datetime <= hi and row["end_time"].datetime >= lo:
+                ax.axvspan(
+                    max(row["start_time"].datetime, lo),
+                    min(row["end_time"].datetime, hi),
+                    color="tab:blue",
+                    alpha=0.15,
+                )
+        for name, style in vline_styles.items():
+            ax.axvline(event[name].datetime, color="tab:red", linestyle=style, alpha=0.9)
+
+        nearest_idx = int(
+            np.argmin(np.abs((our_peaks - event["peak_time"].datetime64) / np.timedelta64(1, "m")))
+        )
+        ax.axvline(
+            flares_1min["peak_time"][nearest_idx].datetime,
+            color="steelblue",
+            linestyle=vline_styles["peak_time"],
+            alpha=0.9,
+        )
+
+        ax.set_yscale("log")
+        title = f"{event['goes_class']} {peak:%m-%d %H:%M}"
+        diagnosis = diagnose_miss(merged_1min, peak)
+        if diagnosis is not None:
+            title += f"\n({diagnosis})"
+        ax.set_title(title, fontsize=9)
+        ax.tick_params(axis="x", labelsize=6, rotation=30)
+        ax.tick_params(axis="y", labelsize=7)
+
+    for ax in axes.flat[len(missed_events):]:
+        ax.axis("off")
+
+    fig.suptitle(
+        "HEK flares not detected by our algorithm\n"
+        "(red = HEK start/peak/end; steelblue = our nearest peak; "
+        "blue shading = a nearby detection of ours, if any)"
+    )
+    fig.tight_layout(rect=[0, 0, 1, 0.97])
+    plt.show()
+    return missed_events
+
+
+###############################################################################
+# The other direction matters too: events we detect that HEK doesn't report
+# at all. These aren't necessarily wrong, HEK's automated list has gaps of
+# its own, but a cluster of them is worth a look, especially in a quiet
+# period where a much lower detection threshold makes us far more sensitive
+# to noise and instrumental artifacts (see the electron contamination
+# correction discussed above).
+
+
+def plot_extra_events(hek_events, flares_1min, merged_1min, window=pd.Timedelta(minutes=25)):
+    hek_peaks = np.array([event["peak_time"].datetime64 for event in hek_events])
+    extra_events = [
+        row
+        for row in flares_1min
+        if len(hek_peaks) == 0
+        or np.abs((hek_peaks - row["peak_time"].datetime64) / np.timedelta64(1, "m")).min() > 5
+    ]
+    print(f"{len(extra_events)} of {len(flares_1min)} detections have no matching HEK event")
+
+    if not extra_events:
+        return extra_events
+
+    ncols = 4
+    nrows = int(np.ceil(len(extra_events) / ncols))
+    fig, axes = plt.subplots(nrows, ncols, figsize=(3.2 * ncols, 2.4 * nrows), squeeze=False)
+
+    for ax, row in zip(axes.flat, extra_events):
+        peak = pd.Timestamp(row["peak_time"].datetime)
+        lo, hi = peak - window, peak + window
+        segment = merged_1min.loc[lo:hi]
+        ax.plot(segment.index, segment.to_numpy(), color="black", lw=1)
+        ax.set_xlim(lo, hi)
+
+        for event in hek_events:
+            if event["start_time"].datetime <= hi and event["end_time"].datetime >= lo:
+                ax.axvspan(
+                    max(event["start_time"].datetime, lo),
+                    min(event["end_time"].datetime, hi),
+                    color="tab:red",
+                    alpha=0.15,
+                )
+        for name, style in vline_styles.items():
+            ax.axvline(row[name].datetime, color="steelblue", linestyle=style, alpha=0.9)
+
+        ax.set_yscale("log")
+        ax.set_title(f"{row['goes_class']} {peak:%m-%d %H:%M}", fontsize=9)
+        ax.tick_params(axis="x", labelsize=6, rotation=30)
+        ax.tick_params(axis="y", labelsize=7)
+
+    for ax in axes.flat[len(extra_events):]:
+        ax.axis("off")
+
+    fig.suptitle(
+        "Our detections with no matching HEK event\n"
+        "(steelblue = our start/peak/end; red shading = a nearby HEK event, if any)"
+    )
+    fig.tight_layout(rect=[0, 0, 1, 0.97])
+    plt.show()
+    return extra_events
+
+
+###############################################################################
+# `~sunkit_instruments.goes_xrs.find_goes_flares` reverse engineers several
+# refinements on top of NOAA's own 3-rule description of start, peak and end
+# (an extending-window search for the rise ratio, a peak-locking mechanism,
+# and noise-tolerant patching of an interrupted decay's end time) to better
+# match the official list. `~sunkit_instruments.goes_xrs.find_flares_naive`
+# implements *only* those 3 rules exactly as described, in a single pass,
+# with none of that extra machinery, so we can compare the two against each
+# other below.
+
+
+def match_fraction(flares, hek_events, tol_min=5):
+    peaks = flares["peak_time"].datetime64
+    matched = sum(
+        1
+        for event in hek_events
+        if np.abs((peaks - event["peak_time"].datetime64) / np.timedelta64(1, "m")).min() <= tol_min
+    )
+    return matched, len(hek_events)
+
+
+###############################################################################
+# Active period
+# -------------
+# GOES-16 was the primary satellite throughout May 2024, with GOES-18 as its
+# secondary.
+
+tr = a.Time("2024-05-10 00:00", "2024-05-15 23:59")
+# if offline run for entire moth or longer
+# tr = a.Time("2024-05-01 00:00", "2024-05-31 23:59")
+
+merged_1s, merged_1min = fetch_merged_fluxes(tr, satellites=(16, 18))
+
+MIN_CLASS = "B1.0"
+
+hek_events = get_goes_event_list(TimeRange(tr.start, tr.end), goes_class_filter=MIN_CLASS)
+
+print("Flares reported in the official GOES event list (from the HEK):", len(hek_events))
+
+###############################################################################
+# Quiet period
+# ------------
+# Now let's set up a quiet period too, during solar minimum, where the
+# largest flare is only A-class. GOES-16 was still the primary satellite in
+# May 2020, but its secondary at the time was GOES-17 rather than GOES-18.
+# Since we're now looking for much weaker events, we also lower ``min_class``
+# and ``flux_threshold`` (the quiet-Sun background floor used to detect a
+# rise at all) from the B1.0 defaults down to A1.0.
+#
+# (some of the extra events will dispear if use the extended info in the 1min avg files)
+
+tr_quiet = a.Time("2020-05-01 00:00", "2020-05-31 23:59")
+
+merged_1s_quiet, merged_1min_quiet = fetch_merged_fluxes(tr_quiet, satellites=(16, 17))
+
+MIN_CLASS_QUIET = "A1.0"
+
+hek_events_quiet = get_goes_event_list(
+    TimeRange(tr_quiet.start, tr_quiet.end), goes_class_filter=MIN_CLASS_QUIET
+)
+
+print("Flares reported in the official GOES event list (from the HEK):", len(hek_events_quiet))
+
+###############################################################################
+# Naive method
+# ------------
+# Let's first see how the naive, 3-rule-only method does against the
+# official list, on both periods, using the 1-minute averaged flux for each
+# (the algorithm is defined for 1-minute averages).
+
+naive_flares = find_flares_naive(
+    Time(merged_1min.index.values, format="datetime64"),
+    merged_1min.to_numpy() * u.W / u.m**2,
+    min_flux=flareclass_to_flux(MIN_CLASS),
+    flux_threshold=flareclass_to_flux(MIN_CLASS),
+)
+naive_matched, total = match_fraction(naive_flares, hek_events)
+print(
+    f"Naive (3-rule) method, active period: {len(naive_flares)} flares detected, "
+    f"{naive_matched}/{total} HEK events matched"
+)
+
+naive_flares_quiet = find_flares_naive(
+    Time(merged_1min_quiet.index.values, format="datetime64"),
+    merged_1min_quiet.to_numpy() * u.W / u.m**2,
+    min_flux=flareclass_to_flux(MIN_CLASS_QUIET),
+    flux_threshold=flareclass_to_flux(MIN_CLASS_QUIET),
+)
+naive_matched_quiet, total_quiet = match_fraction(naive_flares_quiet, hek_events_quiet)
+print(
+    f"Naive (3-rule) method, quiet period:  {len(naive_flares_quiet)} flares detected, "
+    f"{naive_matched_quiet}/{total_quiet} HEK events matched"
+)
+
+###############################################################################
+# Improved method
+# ----------------
+# Now let's see how `~sunkit_instruments.goes_xrs.find_goes_flares` does on
+# the same two periods. Both cadences typically agree closely with each
+# other, and recover substantially more of the events in the official list
+# than the naive method above. It only implements the *automated* part of
+# NOAA's detection algorithm though, and most of the remaining gap comes from
+# local sub-peaks that occur during a single, still-elevated, complex flare:
+# NOAA's list reports these as their own separate events, while our peak,
+# once locked in, only starts a new flare after flux has clearly turned over
+# for a sustained period. A smaller share of the gap is made up of slow,
+# gradual events whose rise is never steep enough to trip the automated
+# trigger at all, which the official list can include via manual entries
+# from SWPC operators.
+#
+# To see this, we stack three panels, one each for the 1-second detections,
+# the 1-minute detections, and the official HEK list, and separately plot
+# the HEK events our algorithm missed.
+
+flares_1s = to_flares(merged_1s, min_class=MIN_CLASS)
+flares_1min = to_flares(merged_1min, min_class=MIN_CLASS)
+
+print("Flares detected from 1-second data:", len(flares_1s))
+print("Flares detected from 1-minute averaged data:", len(flares_1min))
+
+refined_matched, _ = match_fraction(flares_1min, hek_events)
+print(
+    f"Improved method, active period:       {len(flares_1min)} flares detected, "
+    f"{refined_matched}/{total} HEK events matched"
+)
+
+###############################################################################
+# Now let see a comparison
+
+plot_comparison(
+    merged_1min,
+    flares_1s,
+    flares_1min,
+    hek_events,
+    "Long channel flux [W/m$^2$] with detected/reported flares",
+)
+
+
+###############################################################################
+# Missed events compare to HEK
+
+missed_events = plot_missed_events(hek_events, flares_1min, merged_1min)
+
+###############################################################################
+# Extra events we detect that HEK doesn't report
+
+extra_events = plot_extra_events(hek_events, flares_1min, merged_1min)
+
+flares_1s_quiet = to_flares(
+    merged_1s_quiet, min_class=MIN_CLASS_QUIET, flux_threshold=flareclass_to_flux(MIN_CLASS_QUIET)
+)
+flares_1min_quiet = to_flares(
+    merged_1min_quiet, min_class=MIN_CLASS_QUIET, flux_threshold=flareclass_to_flux(MIN_CLASS_QUIET)
+)
+
+print("Flares detected from 1-second data:", len(flares_1s_quiet))
+print("Flares detected from 1-minute averaged data:", len(flares_1min_quiet))
+
+refined_matched_quiet, _ = match_fraction(flares_1min_quiet, hek_events_quiet)
+print(
+    f"Improved method, quiet period:        {len(flares_1min_quiet)} flares detected, "
+    f"{refined_matched_quiet}/{total_quiet} HEK events matched"
+)
+
+###############################################################################
+# Now let see a comparison
+
+plot_comparison(
+    merged_1min_quiet,
+    flares_1s_quiet,
+    flares_1min_quiet,
+    hek_events_quiet,
+    "Long channel flux [W/m$^2$] with detected/reported flares (quiet period)",
+)
+
+###############################################################################
+# Missed events compare to HEK
+
+missed_events_quiet = plot_missed_events(hek_events_quiet, flares_1min_quiet, merged_1min_quiet)
+
+###############################################################################
+# Extra events we detect that HEK doesn't report
+
+extra_events_quiet = plot_extra_events(hek_events_quiet, flares_1min_quiet, merged_1min_quiet)

--- a/sunkit_instruments/goes_xrs/__init__.py
+++ b/sunkit_instruments/goes_xrs/__init__.py
@@ -1,2 +1,3 @@
+from .flare_detection import *  # NOQA
 from .goes_chianti_tem import *  # NOQA
 from .goes_xrs import *  # NOQA

--- a/sunkit_instruments/goes_xrs/flare_detection.py
+++ b/sunkit_instruments/goes_xrs/flare_detection.py
@@ -515,6 +515,9 @@ def find_goes_flares(goes_ts, min_class="C1", **kwargs):
     times = Time(longflux.index.values, format="datetime64")
     flux = u.Quantity(longflux.to_numpy(), "W/m**2")
 
+    if "min_flux" in kwargs:
+        raise TypeError("min_flux is derived from min_class; pass min_class instead.")
+
     flares = find_flares(times, flux, min_flux=flareclass_to_flux(min_class), **kwargs)
     flares["goes_class"] = [flux_to_flareclass(peak_flux) for peak_flux in flares["peak_flux"]]
     return flares["start_time", "peak_time", "end_time", "goes_class", "peak_flux"]

--- a/sunkit_instruments/goes_xrs/flare_detection.py
+++ b/sunkit_instruments/goes_xrs/flare_detection.py
@@ -1,0 +1,520 @@
+import numpy as np
+import pandas as pd
+
+import astropy.units as u
+from astropy.table import QTable
+from astropy.time import Time
+
+from sunpy import timeseries as ts
+
+from .goes_xrs import flareclass_to_flux, flux_to_flareclass
+
+__all__ = ["find_flares_naive", "find_flares", "find_goes_flares"]
+
+
+def find_flares_naive(
+    times,
+    flux,
+    min_flux=1e-6 * u.W / u.m**2,
+    flux_threshold=1e-7 * u.W / u.m**2,
+    min_rise_time=4 * u.min,
+    min_rise_ratio=1.4,
+    min_decay_time=4 * u.min,
+    decay_fraction=0.5,
+    cadence=1 * u.min,
+):
+    """
+    Detect flares in a timeseries using a literal reading of NOAA's 3-rule
+    description, with none of the extra refinements `find_flares` adds to
+    better match the official GOES flare list:
+
+    * A flare starts at the first sample, ``i``, where flux is at least
+      ``flux_threshold`` and rises, uninterrupted, for exactly
+      ``min_rise_time``, reaching a value more than ``min_rise_ratio`` times
+      the flux at ``i`` within that fixed window. Unlike `find_flares`, the
+      ratio is not given any further samples to build towards if it is not
+      met within this window alone.
+    * The flare peaks at the maximum flux reached before the flux falls for
+      ``min_decay_time`` consecutive samples, exactly as in `find_flares`.
+    * The flare ends once the flux has decayed ``decay_fraction`` of the way
+      back down from the peak flux to the flux at the start of the rise. If
+      that level is never reached before the data ends, or before a later,
+      unrelated flare's own decay happens to cross it, the end time is
+      whatever sample the plain scan first satisfies this at, rather than
+      being patched against the next flare's start.
+
+    This function exists to demonstrate the effect of those refinements: it
+    recovers substantially fewer of the officially reported GOES flares than
+    `find_flares` does, and is not intended for production use.
+
+    The algorithm is defined for 1-minute averaged flux, so ``times`` and
+    ``flux`` are first rebinned onto the requested ``cadence`` (by averaging)
+    regardless of their native sampling.
+
+    Parameters
+    ----------
+    times : `~astropy.time.Time`
+        The time of each measurement.
+    flux : `~astropy.units.Quantity`
+        The measured signal to search for flares in, in any unit. NaN values
+        are treated as data gaps and are never considered part of a rise or
+        decay.
+    min_flux : `~astropy.units.Quantity`, optional
+        The minimum peak flux for a flare to be included in the returned table.
+        Must be convertible to the unit of ``flux``. Defaults to 1e-6 W/m**2
+        (i.e. GOES class C1). Pass `None` to disable filtering.
+    flux_threshold : `~astropy.units.Quantity`, optional
+        The minimum flux for a rise to be considered above the quiet-Sun
+        background at all. Must be convertible to the unit of ``flux``.
+        Defaults to 1e-7 W/m**2 (i.e. GOES class B1).
+    min_rise_time : `~astropy.units.Quantity`, optional
+        The exact duration over which the rise ratio must be met. Defaults to
+        4 minutes. Internally converted to a number of rebinned samples using
+        ``cadence``, so must be at least two ``cadence``.
+    min_rise_ratio : `float`, optional
+        The minimum ratio between the flux at the end and at the start of the
+        rise window for it to be considered a genuine flare. Defaults to 1.4.
+    min_decay_time : `~astropy.units.Quantity`, optional
+        The duration of consecutively decreasing flux that marks the end of
+        the rise to peak flux. Defaults to 4 minutes. Internally converted to
+        a number of rebinned samples using ``cadence``, so must be at least
+        one ``cadence``.
+    decay_fraction : `float`, optional
+        The fraction of the way back down from the peak flux to the pre-flare
+        background flux that defines the end of a flare. Defaults to 0.5.
+    cadence : `~astropy.units.Quantity`, optional
+        The cadence that ``times`` and ``flux`` are rebinned onto (by
+        averaging) before the algorithm is run. Defaults to 1 minute.
+
+    Returns
+    -------
+    `~astropy.table.QTable`
+        A table of the detected flares with columns ``start_time``, ``peak_time``,
+        ``end_time`` and ``peak_flux``.
+
+    See Also
+    --------
+    find_flares : the refined version of this algorithm used elsewhere in
+        this package, which recovers substantially more of the officially
+        reported GOES flares.
+
+    References
+    ----------
+    * `GOES XRS Guide <https://ngdc.noaa.gov/stp/satellite/goes/doc/GOES_XRS_readme.pdf>`__
+    """
+    if len(times) != len(flux):
+        raise ValueError(
+            f"times and flux must be the same length, got {len(times)} and {len(flux)}."
+        )
+
+    if not isinstance(flux, u.Quantity):
+        raise TypeError(f"flux must be an astropy Quantity, not {type(flux)}")
+    flux_unit = flux.unit
+    flux = flux.value
+
+    if min_flux is not None and not isinstance(min_flux, u.Quantity):
+        raise TypeError(f"min_flux must be an astropy Quantity or None, not {type(min_flux)}")
+    if not isinstance(flux_threshold, u.Quantity):
+        raise TypeError(f"flux_threshold must be an astropy Quantity, not {type(flux_threshold)}")
+
+    threshold_flux = -np.inf if min_flux is None else min_flux.to_value(flux_unit)
+    detection_floor = flux_threshold.to_value(flux_unit)
+
+    n_rise_samples = round((min_rise_time / cadence).to_value(u.dimensionless_unscaled))
+    n_decay_samples = round((min_decay_time / cadence).to_value(u.dimensionless_unscaled))
+    if n_rise_samples < 2 or n_decay_samples < 1:
+        raise ValueError(
+            "min_rise_time must be at least two cadences, and min_decay_time at least one."
+        )
+
+    series = pd.Series(flux, index=pd.DatetimeIndex(times.datetime64))
+    series = series.resample(pd.Timedelta(cadence.to_value(u.s), unit="s")).mean()
+
+    times = Time(series.index.values, format="datetime64")
+    flux = series.to_numpy()
+    n = len(flux)
+
+    start_indices, peak_indices, end_indices, peak_fluxes = [], [], [], []
+
+    i = 0
+    while i <= n - n_rise_samples:
+        window = flux[i : i + n_rise_samples]
+        if np.any(np.isnan(window)) or window[0] < detection_floor:
+            i += 1
+            continue
+        if not np.all(np.diff(window) > 0) or not (window[-1] > min_rise_ratio * window[0]):
+            i += 1
+            continue
+
+        # `i` is the pre-flare background level. As in `find_flares`, the
+        # peak is locked in as soon as flux has been falling for
+        # `n_decay_samples` consecutive samples.
+        background = flux[i]
+        peak_index = i
+        peak_flux = flux[i]
+        consecutive_decreases = 0
+        previous_flux = peak_flux
+
+        j = i + 1
+        while j < n:
+            current_flux = flux[j]
+            if np.isnan(current_flux):
+                consecutive_decreases = 0
+                j += 1
+                continue
+
+            if current_flux > peak_flux:
+                peak_flux = current_flux
+                peak_index = j
+                consecutive_decreases = 0
+            elif current_flux < previous_flux:
+                consecutive_decreases += 1
+                if consecutive_decreases >= n_decay_samples:
+                    break
+            else:
+                consecutive_decreases = 0
+
+            previous_flux = current_flux
+            j += 1
+
+        # Unlike `find_flares`, a plain scan for the first sample that
+        # reaches `decay_level`: no check for whether a later uptick is a
+        # genuine new rise, and no patching against the next flare's start if
+        # that level is never reached.
+        decay_level = background + (peak_flux - background) * (1 - decay_fraction)
+        end_index = n - 1
+        for k in range(peak_index + 1, n):
+            if not np.isnan(flux[k]) and flux[k] <= decay_level:
+                end_index = k
+                break
+
+        if peak_flux >= threshold_flux:
+            start_indices.append(i)
+            peak_indices.append(peak_index)
+            end_indices.append(end_index)
+            peak_fluxes.append(peak_flux)
+
+        i = peak_index + 1
+
+    return QTable(
+        {
+            "start_time": times[start_indices],
+            "peak_time": times[peak_indices],
+            "end_time": times[end_indices],
+            "peak_flux": u.Quantity(peak_fluxes, flux_unit),
+        }
+    )
+
+
+def _rise_starts_at(flux, i, n, detection_floor, min_rise_ratio, n_rise_samples):
+    """
+    Whether a genuine rise starts at index `i`: an uninterrupted monotonic
+    increase, staying above `detection_floor`, that is at least
+    `n_rise_samples` long and at some point exceeds `min_rise_ratio` times
+    the flux at `i`.
+    """
+    if np.isnan(flux[i]) or flux[i] < detection_floor:
+        return False
+    j = i + 1
+    while j < n:
+        current_flux = flux[j]
+        if np.isnan(current_flux) or current_flux <= flux[j - 1]:
+            return False
+        if j - i + 1 >= n_rise_samples and current_flux > min_rise_ratio * flux[i]:
+            return True
+        j += 1
+    return False
+
+
+def find_flares(
+    times,
+    flux,
+    min_flux=1e-6 * u.W / u.m**2,
+    flux_threshold=1e-7 * u.W / u.m**2,
+    min_rise_time=4 * u.min,
+    min_rise_ratio=1.4,
+    min_decay_time=4 * u.min,
+    decay_fraction=0.5,
+    cadence=1 * u.min,
+):
+    """
+    Detect flares in a timeseries.
+
+    This implements a reverse engineered version of NOAA SWPC algorithm used
+    to build the official GOES flare lists:
+
+    * A flare starts at the first sample, ``i``, of an uninterrupted run of
+      increasing flux above ``flux_threshold`` that is at least
+      ``min_rise_time`` long and, at some point along the way, reaches a
+      value more than ``min_rise_ratio`` times the flux at ``i``. Real flares
+      often build gradually, so this ratio need not be met within the first
+      ``min_rise_time`` alone; as long as the rise stays uninterrupted, later
+      samples still count towards the same candidate start.
+    * The flare peaks at the maximum flux reached before the flux falls for
+      ``min_decay_time`` consecutive samples: once that many consecutive
+      samples of decrease are seen, the peak is locked in, and a later,
+      stronger re-brightening starts its own, separate flare rather than
+      being folded into this one.
+    * The flare ends once the flux has decayed ``decay_fraction`` of the way
+      back down from the peak flux to the flux at the start of the rise (0.5,
+      i.e. half way back to the pre-flare background, by default). If a new
+      rise begins before that level is reached, the decay is considered
+      interrupted, and this flare's end is set to that next flare's start
+      instead, matching the convention used in the official GOES event lists.
+
+    The algorithm is defined for 1-minute averaged flux, so ``times`` and
+    ``flux`` are first rebinned onto the requested ``cadence`` (by averaging)
+    regardless of their native sampling.
+
+    Notes
+    -----
+    This is the automated detection algorithm; the official NOAA/GOES event
+    list also includes events added manually by SWPC operators for edge cases
+    the automated algorithm cannot handle. This function will not find those.
+
+    Parameters
+    ----------
+    times : `~astropy.time.Time`
+        The time of each measurement.
+    flux : `~astropy.units.Quantity`
+        The measured signal to search for flares in, in any unit. This need
+        not be a physically calibrated flux; a detector count rate or data
+        number works just as well, as long as ``min_flux`` and
+        ``flux_threshold`` are given in a compatible unit. NaN values are
+        treated as data gaps and are never considered part of a rise or decay.
+    min_flux : `~astropy.units.Quantity`, optional
+        The minimum peak flux for a flare to be included in the returned table.
+        This only filters the returned table; it does not affect detection
+        (see ``flux_threshold`` for that). Must be convertible to the unit of
+        ``flux``. Defaults to 1e-6 W/m**2 (i.e. GOES class C1). Pass `None`
+        to disable filtering.
+    flux_threshold : `~astropy.units.Quantity`, optional
+        The minimum flux for samples to be considered above the quiet-Sun
+        background at all. Must be convertible to the unit of ``flux``.
+        Defaults to 1e-7 W/m**2 (i.e. GOES class B1), matching the NOAA
+        algorithm.
+    min_rise_time : `~astropy.units.Quantity`, optional
+        The duration of consecutively increasing flux that marks the start of a
+        flare. Defaults to 4 minutes. Internally converted to a number of
+        rebinned samples using ``cadence``, so must be at least two ``cadence``.
+    min_rise_ratio : `float`, optional
+        The minimum ratio between the flux at the end and at the start of the
+        rise window for it to be considered a genuine flare, rather than a
+        marginal fluctuation in the background. Defaults to 1.4, matching the
+        NOAA algorithm.
+    min_decay_time : `~astropy.units.Quantity`, optional
+        The duration of consecutively decreasing flux that marks the end of the
+        rise to peak flux. Defaults to 4 minutes. Internally converted to a
+        number of rebinned samples using ``cadence``, so must be at least one
+        ``cadence``.
+    decay_fraction : `float`, optional
+        The fraction of the way back down from the peak flux to the pre-flare
+        background flux that defines the end of a flare. Defaults to 0.5,
+        i.e. the flare ends when the flux decays half way back to the
+        background level, matching the NOAA algorithm.
+    cadence : `~astropy.units.Quantity`, optional
+        The cadence that ``times`` and ``flux`` are rebinned onto (by averaging)
+        before the algorithm is run. Defaults to 1 minute, matching the standard
+        NOAA algorithm.
+
+    Returns
+    -------
+    `~astropy.table.QTable`
+        A table of the detected flares with columns ``start_time``, ``peak_time``,
+        ``end_time`` and ``peak_flux``.
+
+    References
+    ----------
+    * `GOES XRS Guide <https://ngdc.noaa.gov/stp/satellite/goes/doc/GOES_XRS_readme.pdf>`__
+    """
+    if len(times) != len(flux):
+        raise ValueError(
+            f"times and flux must be the same length, got {len(times)} and {len(flux)}."
+        )
+
+    if not isinstance(flux, u.Quantity):
+        raise TypeError(f"flux must be an astropy Quantity, not {type(flux)}")
+    flux_unit = flux.unit
+    flux = flux.value
+
+    if min_flux is not None and not isinstance(min_flux, u.Quantity):
+        raise TypeError(f"min_flux must be an astropy Quantity or None, not {type(min_flux)}")
+    if not isinstance(flux_threshold, u.Quantity):
+        raise TypeError(f"flux_threshold must be an astropy Quantity, not {type(flux_threshold)}")
+
+    threshold_flux = -np.inf if min_flux is None else min_flux.to_value(flux_unit)
+    detection_floor = flux_threshold.to_value(flux_unit)
+
+    n_rise_samples = round((min_rise_time / cadence).to_value(u.dimensionless_unscaled))
+    n_decay_samples = round((min_decay_time / cadence).to_value(u.dimensionless_unscaled))
+    if n_rise_samples < 2 or n_decay_samples < 1:
+        raise ValueError(
+            "min_rise_time must be at least two cadences, and min_decay_time at least one."
+        )
+
+    series = pd.Series(flux, index=pd.DatetimeIndex(times.datetime64))
+    series = series.resample(pd.Timedelta(cadence.to_value(u.s), unit="s")).mean()
+
+    times = Time(series.index.values, format="datetime64")
+    flux = series.to_numpy()
+    n = len(flux)
+
+    # Collect every candidate event first, regardless of `min_flux`, so that
+    # an interrupted flare's end can always be patched against the very next
+    # flare found (see below), not just the next one that happens to pass
+    # the `min_flux` filter.
+    all_start_indices, all_peak_indices, all_end_indices = [], [], []
+    all_peak_fluxes, all_end_confirmed = [], []
+
+    i = 0
+    while i <= n - n_rise_samples:
+        # Real flares often build gradually, so `min_rise_ratio` is frequently
+        # not met within the first `n_rise_samples` samples alone; as long as
+        # the rise from `i` is uninterrupted, later samples still count
+        # towards the same candidate start at `i`.
+        if not _rise_starts_at(flux, i, n, detection_floor, min_rise_ratio, n_rise_samples):
+            i += 1
+            continue
+
+        # `i` is the pre-flare background level. The peak is locked in as soon
+        # as flux has been falling for `n_decay_samples` consecutive samples:
+        # a later, stronger re-brightening starts its own, separate flare
+        # rather than being folded into this one.
+        background = flux[i]
+        peak_index = i
+        peak_flux = flux[i]
+        consecutive_decreases = 0
+        previous_flux = peak_flux
+
+        j = i + 1
+        while j < n:
+            current_flux = flux[j]
+            if np.isnan(current_flux):
+                consecutive_decreases = 0
+                j += 1
+                continue
+
+            if current_flux > peak_flux:
+                peak_flux = current_flux
+                peak_index = j
+                consecutive_decreases = 0
+            elif current_flux < previous_flux:
+                consecutive_decreases += 1
+                if consecutive_decreases >= n_decay_samples:
+                    break
+            else:
+                consecutive_decreases = 0
+
+            previous_flux = current_flux
+            j += 1
+
+        # The flare ends once flux has decayed `decay_fraction` of the way
+        # back down from the (now locked) peak to the pre-flare background.
+        # A local uptick alone doesn't interrupt this search (that would make
+        # the end far too sensitive to ordinary noise in the decay); it only
+        # does so if it is the start of a genuine new rise, in which case the
+        # end is filled in below, once that next flare's own start is known.
+        decay_level = background + (peak_flux - background) * (1 - decay_fraction)
+        end_index = None
+        previous_flux = peak_flux
+        previous_index = peak_index
+        k = peak_index + 1
+        while k < n:
+            current_flux = flux[k]
+            if np.isnan(current_flux):
+                k += 1
+                continue
+            if current_flux <= decay_level:
+                end_index = k
+                break
+            if current_flux > previous_flux and _rise_starts_at(
+                flux, previous_index, n, detection_floor, min_rise_ratio, n_rise_samples
+            ):
+                break
+            previous_flux = current_flux
+            previous_index = k
+            k += 1
+
+        all_start_indices.append(i)
+        all_peak_indices.append(peak_index)
+        all_end_indices.append(end_index if end_index is not None else n - 1)
+        all_end_confirmed.append(end_index is not None)
+        all_peak_fluxes.append(peak_flux)
+
+        i = peak_index + 1
+
+    # A flare whose decay was interrupted by the next one starting shares its
+    # end time with that next flare's start, rather than an arbitrary or
+    # missing value; this also matches the convention used in the official
+    # GOES event lists.
+    for idx in range(len(all_end_indices) - 1):
+        if not all_end_confirmed[idx]:
+            all_end_indices[idx] = all_start_indices[idx + 1]
+
+    start_indices, peak_indices, end_indices, peak_fluxes = [], [], [], []
+    for start, peak, end, peak_flux in zip(
+        all_start_indices, all_peak_indices, all_end_indices, all_peak_fluxes
+    ):
+        if peak_flux >= threshold_flux:
+            start_indices.append(start)
+            peak_indices.append(peak)
+            end_indices.append(end)
+            peak_fluxes.append(peak_flux)
+
+    return QTable(
+        {
+            "start_time": times[start_indices],
+            "peak_time": times[peak_indices],
+            "end_time": times[end_indices],
+            "peak_flux": u.Quantity(peak_fluxes, flux_unit),
+        }
+    )
+
+
+def find_goes_flares(goes_ts, min_class="C1", **kwargs):
+    """
+    Detect flares in a GOES XRS timeseries.
+
+    This extracts the long channel (``xrsb``) flux of ``goes_ts`` and runs it
+    through `~sunkit_instruments.goes_xrs.find_flares`, which implements a version
+    of the NOAA SWPC algorithm used to build the official GOES flare lists,
+    then classifies each detected flare's peak flux into a GOES class.
+
+    Parameters
+    ----------
+    goes_ts : `~sunpy.timeseries.sources.XRSTimeSeries`
+        The GOES XRS timeseries containing the long channel (``xrsb``) flux (in W/m**2).
+    min_class : `str`, optional
+        The minimum GOES class for a flare to be included in the returned table,
+        e.g. "C1", "M1". Defaults to "C1".
+    **kwargs :
+        Additional keyword arguments are passed to `~sunkit_instruments.goes_xrs.find_flares`.
+
+    Returns
+    -------
+    `~astropy.table.QTable`
+        A table of the detected flares with columns ``start_time``, ``peak_time``,
+        ``end_time``, ``goes_class`` and ``peak_flux``.
+
+    References
+    ----------
+    * `GOES XRS Guide <https://ngdc.noaa.gov/stp/satellite/goes/doc/GOES_XRS_readme.pdf>`__
+    """
+    if not isinstance(goes_ts, ts.XRSTimeSeries):
+        raise TypeError(
+            f"Input time series must be a XRSTimeSeries instance, not {type(goes_ts)}"
+        )
+    if "xrsb" not in goes_ts.columns:
+        raise ValueError("The input time series does not contain a 'xrsb' column.")
+
+    df = goes_ts.to_dataframe()
+    longflux = df["xrsb"].copy()
+    if "xrsb_quality" in df.columns:
+        longflux[df["xrsb_quality"] != 0] = np.nan
+
+    times = Time(longflux.index.values, format="datetime64")
+    flux = u.Quantity(longflux.to_numpy(), "W/m**2")
+
+    flares = find_flares(times, flux, min_flux=flareclass_to_flux(min_class), **kwargs)
+    flares["goes_class"] = [flux_to_flareclass(peak_flux) for peak_flux in flares["peak_flux"]]
+    return flares["start_time", "peak_time", "end_time", "goes_class", "peak_flux"]

--- a/sunkit_instruments/goes_xrs/goes_xrs.py
+++ b/sunkit_instruments/goes_xrs/goes_xrs.py
@@ -170,7 +170,11 @@ def flux_to_flareclass(goesflux: u.watt / u.m**2):
     if goesflux.value < 0:
         raise ValueError("Flux cannot be negative")
 
-    decade = np.floor(np.log10(goesflux.to("W/m**2").value))
+    # Cast to a native int so that the `10**decade` lookup below is computed
+    # in full double precision, regardless of the input flux's dtype (e.g.
+    # float32 flux, as is common in netCDF-sourced GOES data, would otherwise
+    # make `10**decade` miss the `GOES_CONVERSION_DICT` keys by a tiny amount).
+    decade = int(np.floor(np.log10(goesflux.to("W/m**2").value)))
     # invert the conversion dictionary
     conversion_dict = {v: k for k, v in GOES_CONVERSION_DICT.items()}
     if decade < -8:

--- a/sunkit_instruments/goes_xrs/tests/test_flare_detection.py
+++ b/sunkit_instruments/goes_xrs/tests/test_flare_detection.py
@@ -1,0 +1,357 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import astropy.units as u
+from astropy.table import QTable
+from astropy.time import Time
+
+from sunpy import timeseries as ts
+
+from sunkit_instruments import goes_xrs as goes
+
+BACKGROUND = 1e-7
+
+
+def _make_xrs_timeseries(flux, quality=None, cadence="1min", start="2020-01-01"):
+    n = len(flux)
+    idx = pd.date_range(start, periods=n, freq=cadence)
+    data = {"xrsa": flux * 0.5, "xrsb": flux}
+    if quality is not None:
+        data["xrsb_quality"] = quality
+    df = pd.DataFrame(data, index=idx)
+    units = {"xrsa": u.W / u.m**2, "xrsb": u.W / u.m**2}
+    if quality is not None:
+        units["xrsb_quality"] = u.dimensionless_unscaled
+    return ts.TimeSeries(df, {}, units, source="xrs")
+
+
+def _add_flare(flux, start, rise_len, peak_val, decay_tau, decay_len):
+    flux = flux.copy()
+    flux[start : start + rise_len] = np.linspace(flux[start], peak_val, rise_len)
+    decay_idx = np.arange(1, decay_len)
+    decay = BACKGROUND + (peak_val - BACKGROUND) * np.exp(-decay_idx / decay_tau)
+    flux[start + rise_len : start + rise_len + decay_len - 1] = decay
+    return flux
+
+
+def _make_times(n, cadence="1min", start="2020-01-01"):
+    return Time(pd.date_range(start, periods=n, freq=cadence).values, format="datetime64")
+
+
+def test_find_goes_flares_single_flare():
+    flux = np.full(60, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-5, 5, 20)
+    goes_ts = _make_xrs_timeseries(flux)
+
+    result = goes.find_goes_flares(goes_ts)
+
+    assert isinstance(result, QTable)
+    assert len(result) == 1
+    assert isinstance(result["start_time"], Time)
+    assert isinstance(result["peak_time"], Time)
+    assert isinstance(result["end_time"], Time)
+    assert result["goes_class"][0] == "M5"
+    assert u.allclose(result["peak_flux"][0], 5e-5 * u.W / u.m**2)
+    assert result["start_time"][0] < result["peak_time"][0] < result["end_time"][0]
+
+
+def test_find_goes_flares_multiple_and_min_class_filter():
+    flux = np.full(120, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-5, 5, 20)  # M5
+    flux = _add_flare(flux, 50, 5, 5e-7, 3, 10)  # B5, below default C1 threshold
+    flux = _add_flare(flux, 80, 8, 2e-4, 6, 25)  # X2
+    goes_ts = _make_xrs_timeseries(flux)
+
+    result_default = goes.find_goes_flares(goes_ts)
+    assert list(result_default["goes_class"]) == ["M5", "X2"]
+
+    result_all = goes.find_goes_flares(goes_ts, min_class="A1")
+    assert list(result_all["goes_class"]) == ["M5", "B5", "X2"]
+
+    result_x_only = goes.find_goes_flares(goes_ts, min_class="X1")
+    assert list(result_x_only["goes_class"]) == ["X2"]
+
+
+def test_find_goes_flares_no_flares():
+    flux = np.full(60, BACKGROUND)
+    goes_ts = _make_xrs_timeseries(flux)
+
+    result = goes.find_goes_flares(goes_ts)
+
+    assert isinstance(result, QTable)
+    assert len(result) == 0
+    assert set(result.colnames) == {
+        "start_time",
+        "peak_time",
+        "end_time",
+        "goes_class",
+        "peak_flux",
+    }
+
+
+def test_find_goes_flares_ignores_bad_quality_data():
+    flux = np.full(60, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-5, 5, 20)
+    quality = np.zeros(60, dtype=int)
+    quality[15] = 1
+    goes_ts = _make_xrs_timeseries(flux, quality=quality)
+
+    result = goes.find_goes_flares(goes_ts)
+
+    assert len(result) == 1
+    assert result["goes_class"][0] == "M5"
+
+
+def test_find_goes_flares_wrong_type():
+    with pytest.raises(TypeError, match="XRSTimeSeries"):
+        goes.find_goes_flares(pd.DataFrame({"xrsb": [1, 2, 3]}))
+
+
+def test_find_goes_flares_missing_column():
+    idx = pd.date_range("2020-01-01", periods=5, freq="1min")
+    df = pd.DataFrame({"foo": np.ones(5)}, index=idx)
+    goes_ts = ts.TimeSeries(df, {}, {"foo": u.W / u.m**2}, source="xrs")
+
+    with pytest.raises(ValueError, match="xrsb"):
+        goes.find_goes_flares(goes_ts)
+
+
+def test_find_flares_accepts_quantity_flux():
+    flux = np.full(60, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-5, 5, 20)
+    times = _make_times(60)
+
+    result = goes.find_flares(times, flux * u.W / u.m**2)
+
+    assert len(result) == 1
+    assert u.allclose(result["peak_flux"][0], 5e-5 * u.W / u.m**2)
+
+
+def test_find_flares_requires_quantity_flux():
+    flux = np.full(60, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-5, 5, 20)
+    times = _make_times(60)
+
+    with pytest.raises(TypeError, match="flux must be an astropy Quantity"):
+        goes.find_flares(times, flux)
+
+
+def test_find_flares_requires_quantity_min_flux_and_flux_threshold():
+    flux = (np.full(60, BACKGROUND) * u.W / u.m**2)
+    times = _make_times(60)
+
+    with pytest.raises(TypeError, match="min_flux must be an astropy Quantity"):
+        goes.find_flares(times, flux, min_flux=1e-6)
+
+    with pytest.raises(TypeError, match="flux_threshold must be an astropy Quantity"):
+        goes.find_flares(times, flux, flux_threshold=1e-7)
+
+
+def test_find_flares_accepts_any_convertible_flux_unit():
+    # Same physical values as a typical flare, but in CGS units (erg/s/cm**2)
+    # instead of W/m**2.
+    flux = np.full(60, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-5, 5, 20)
+    times = _make_times(60)
+
+    flux_cgs = (flux * u.W / u.m**2).to(u.erg / u.s / u.cm**2)
+    result = goes.find_flares(
+        times,
+        flux_cgs,
+        min_flux=1e-3 * u.erg / u.s / u.cm**2,
+        flux_threshold=1e-4 * u.erg / u.s / u.cm**2,
+    )
+
+    assert len(result) == 1
+    assert result["peak_flux"].unit == u.erg / u.s / u.cm**2
+    assert u.allclose(result["peak_flux"][0], (5e-5 * u.W / u.m**2).to(u.erg / u.s / u.cm**2))
+
+
+def test_find_flares_incompatible_threshold_unit_raises():
+    flux = np.full(60, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-5, 5, 20)
+    times = _make_times(60)
+
+    with pytest.raises(u.UnitConversionError):
+        goes.find_flares(times, flux * u.W / u.m**2, min_flux=1 * u.K)
+
+
+def test_find_flares_mismatched_lengths():
+    times = _make_times(60)
+    flux = np.full(30, BACKGROUND)
+
+    with pytest.raises(ValueError, match="same length"):
+        goes.find_flares(times, flux)
+
+
+def test_find_flares_exposes_algorithm_parameters():
+    # A short, fast flare: only 3 minutes of rise (2 increasing steps) and 3 of
+    # decay (2 decreasing steps).
+    flux = np.full(30, BACKGROUND)
+    flux[10:13] = np.linspace(BACKGROUND, 5e-5, 3)
+    flux[13:18] = BACKGROUND + (5e-5 - BACKGROUND) * np.exp(-np.arange(1, 6) / 1.5)
+    times = _make_times(30)
+
+    # With the default min_rise_time/min_decay_time of 4 minutes, this flare is too short to
+    # be detected.
+    result_default = goes.find_flares(times, flux * u.W / u.m**2)
+    assert len(result_default) == 0
+
+    # Lowering min_rise_time/min_decay_time to 2 minutes allows it to be picked up.
+    result_relaxed = goes.find_flares(
+        times, flux * u.W / u.m**2, min_rise_time=2 * u.min, min_decay_time=2 * u.min
+    )
+    assert len(result_relaxed) == 1
+    assert u.allclose(result_relaxed["peak_flux"][0], 5e-5 * u.W / u.m**2)
+
+    # A larger decay_fraction requires the flux to fall further back towards
+    # background before the flare is considered over, pushing the end time later.
+    result_deep_decay = goes.find_flares(
+        times,
+        flux * u.W / u.m**2,
+        min_rise_time=2 * u.min,
+        min_decay_time=2 * u.min,
+        decay_fraction=0.9,
+    )
+    assert result_deep_decay["end_time"][0] > result_relaxed["end_time"][0]
+
+
+def test_find_flares_min_flux_filter():
+    flux = np.full(60, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-7, 3, 20)  # B5
+    times = _make_times(60)
+    flux = flux * u.W / u.m**2
+
+    assert len(goes.find_flares(times, flux, min_flux=1e-6 * u.W / u.m**2)) == 0
+    assert len(goes.find_flares(times, flux, min_flux=1e-7 * u.W / u.m**2)) == 1
+    assert len(goes.find_flares(times, flux, min_flux=None)) == 1
+
+
+def test_find_flares_min_rise_must_be_at_least_two_cadences():
+    times = _make_times(30)
+    flux = np.full(30, BACKGROUND) * u.W / u.m**2
+
+    with pytest.raises(ValueError, match="at least two cadences"):
+        goes.find_flares(times, flux, min_rise_time=30 * u.s, cadence=1 * u.min)
+
+
+def test_find_flares_tracks_peak_through_a_short_dip():
+    # A small bump with only a 3-minute dip (shorter than the default 4-minute
+    # min_decay_time) before a much stronger re-brightening. The dip is too
+    # short to lock in the small bump as the flare's peak, so the bigger
+    # re-brightening is correctly picked up as the same flare's peak.
+    times = _make_times(60)
+    flux = np.full(60, BACKGROUND)
+    flux[10:15] = np.linspace(BACKGROUND, 2e-6, 5)
+    flux[15:19] = np.linspace(2e-6, 1.5e-6, 4)
+    flux[19:29] = np.linspace(1.5e-6, 5e-5, 10)
+    flux[29:45] = BACKGROUND + (5e-5 - BACKGROUND) * np.exp(-np.arange(1, 17) / 5)
+
+    result = goes.find_flares(times, flux * u.W / u.m**2, min_flux=None)
+
+    assert len(result) == 1
+    assert u.allclose(result["peak_flux"][0], 5e-5 * u.W / u.m**2)
+    assert result["start_time"][0] == times[10]
+    assert result["peak_time"][0] == times[28]
+
+
+def test_find_flares_interrupted_decay_ends_at_next_flares_start():
+    # A flare whose decay is interrupted by a second, much stronger flare
+    # before it reaches decay_fraction of the way back to background. The
+    # first flare's end_time should be filled in as the second flare's
+    # start_time, rather than some arbitrary or missing value, matching the
+    # convention used in the official GOES event lists.
+    times = _make_times(80)
+    flux = np.full(80, BACKGROUND)
+    flux[10:20] = np.linspace(BACKGROUND, 2e-5, 10)
+    flux[20:25] = np.linspace(2e-5, 1.5e-5, 5)
+    flux[25:35] = np.linspace(1.6e-5, 8e-5, 10)
+    flux[35:60] = BACKGROUND + (8e-5 - BACKGROUND) * np.exp(-np.arange(1, 26) / 5)
+
+    result = goes.find_flares(times, flux * u.W / u.m**2, min_flux=None)
+
+    assert len(result) == 2
+    assert u.allclose(result["peak_flux"][0], 2e-5 * u.W / u.m**2)
+    assert u.allclose(result["peak_flux"][1], 8e-5 * u.W / u.m**2)
+    assert result["end_time"][0] == result["start_time"][1]
+
+
+def test_find_flares_naive_accepts_quantity_flux():
+    flux = np.full(60, BACKGROUND)
+    flux = _add_flare(flux, 10, 10, 5e-5, 5, 20)
+    times = _make_times(60)
+
+    result = goes.find_flares_naive(times, flux * u.W / u.m**2)
+
+    assert len(result) == 1
+    assert u.allclose(result["peak_flux"][0], 5e-5 * u.W / u.m**2)
+
+
+def test_find_flares_naive_requires_quantity_flux():
+    flux = np.full(60, BACKGROUND)
+    times = _make_times(60)
+
+    with pytest.raises(TypeError, match="flux must be an astropy Quantity"):
+        goes.find_flares_naive(times, flux)
+
+
+def test_find_flares_naive_misses_gradual_rise_that_find_flares_catches():
+    # A rise whose ratio isn't met within the first min_rise_time (4 samples:
+    # 1.18x), but is if the uninterrupted rise is allowed to keep building
+    # (1.48x by the 9th sample). find_flares' extending-window search catches
+    # this; find_flares_naive, checking only the fixed first window, misses
+    # it entirely.
+    times = _make_times(60)
+    flux = np.full(60, BACKGROUND)
+    k = np.arange(16)
+    flux[10:26] = BACKGROUND * (1 + 0.06 * k)
+    peak = flux[25]
+    flux[26:50] = BACKGROUND + (peak - BACKGROUND) * np.exp(-np.arange(1, 25) / 5)
+    flux = flux * u.W / u.m**2
+
+    assert len(goes.find_flares(times, flux, min_flux=None)) == 1
+    assert len(goes.find_flares_naive(times, flux, min_flux=None)) == 0
+
+
+def test_find_flares_naive_does_not_patch_interrupted_decay():
+    # Same fixture as test_find_flares_interrupted_decay_ends_at_next_flares_start.
+    # find_flares patches the first flare's end to the second's start;
+    # find_flares_naive instead keeps scanning straight through the second
+    # flare's rise and only stops once its own decay happens to cross the
+    # first flare's decay level, well after the second flare has started.
+    times = _make_times(80)
+    flux = np.full(80, BACKGROUND)
+    flux[10:20] = np.linspace(BACKGROUND, 2e-5, 10)
+    flux[20:25] = np.linspace(2e-5, 1.5e-5, 5)
+    flux[25:35] = np.linspace(1.6e-5, 8e-5, 10)
+    flux[35:60] = BACKGROUND + (8e-5 - BACKGROUND) * np.exp(-np.arange(1, 26) / 5)
+    flux = flux * u.W / u.m**2
+
+    refined = goes.find_flares(times, flux, min_flux=None)
+    naive = goes.find_flares_naive(times, flux, min_flux=None)
+
+    assert len(refined) == len(naive) == 2
+    assert refined["end_time"][0] == refined["start_time"][1]
+    assert naive["end_time"][0] > naive["start_time"][1]
+
+
+def test_find_flares_rebins_to_requested_cadence():
+    # 30 second cadence data, flare rises and decays over a couple of minutes.
+    n = 240
+    times = _make_times(n, cadence="30s")
+    flux = np.full(n, BACKGROUND)
+    flux = _add_flare(flux, 20, 20, 5e-5, 10, 40)
+    flux = flux * u.W / u.m**2
+
+    result_1min = goes.find_flares(times, flux, cadence=1 * u.min)
+    assert len(result_1min) == 1
+    assert result_1min["peak_flux"][0] > 1e-5 * u.W / u.m**2
+
+    # Rebinning to a coarser 2-minute cadence still detects the flare, just
+    # with fewer, coarser samples backing the same rise/decay durations.
+    result_2min = goes.find_flares(
+        times, flux, cadence=2 * u.min, min_rise_time=4 * u.min, min_decay_time=4 * u.min
+    )
+    assert len(result_2min) == 1
+    assert result_2min["peak_flux"][0] > 1e-5 * u.W / u.m**2

--- a/sunkit_instruments/goes_xrs/tests/test_goes_xrs.py
+++ b/sunkit_instruments/goes_xrs/tests/test_goes_xrs.py
@@ -230,7 +230,7 @@ def test_flux_to_classletter():
 
 
 def test_flux_to_classletter_float32():
-    # regressoin test for float32 flux (e.g. from netCDF-sourced GOES data)
+    # regression test for float32 flux (e.g. from netCDF-sourced GOES data)
     # feed into the `10**decade` lookup would miss
     # `GOES_CONVERSION_DICT` keys by a tiny amount, silently returning "None"
     # instead of the class letter

--- a/sunkit_instruments/goes_xrs/tests/test_goes_xrs.py
+++ b/sunkit_instruments/goes_xrs/tests/test_goes_xrs.py
@@ -229,6 +229,17 @@ def test_flux_to_classletter():
     assert goes.flux_to_flareclass(2.1e-05 * u.watt / u.m**2) == "M2.1"
 
 
+def test_flux_to_classletter_float32():
+    # regressoin test for float32 flux (e.g. from netCDF-sourced GOES data)
+    # feed into the `10**decade` lookup would miss
+    # `GOES_CONVERSION_DICT` keys by a tiny amount, silently returning "None"
+    # instead of the class letter
+    flux = Quantity(np.float32(2.5890481992973946e-05), "W/m**2")
+    assert goes.flux_to_flareclass(flux) == "M2.59"
+    flux = Quantity(np.float32(0.000868848932441324), "W/m**2")
+    assert goes.flux_to_flareclass(flux) == "X8.69"
+
+
 def test_class_to_flux():
     classes = ["A3.49", "A0.23", "M1", "X2.3", "M5.8", "C2.3", "B3.45", "X20"]
     results = Quantity(

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ pass_env =
     # If the user has set a LC override we should follow it
     LC_ALL
 setenv =
+    COVERAGE_FILE={toxinidir}/.coverage
     MPLBACKEND = agg
     SUNPY_SAMPLEDIR = {env:SUNPY_SAMPLEDIR:{toxinidir}/.tox/sample_data/}
     devdeps,build_docs,online: HOME = {envtmpdir}


### PR DESCRIPTION
## PR Description

Attempt to add the "GOES X-ray detection algorithm" defined as
1. A GOES X-ray flare event starts when 4 consecutive 1-min X-ray flux are above the B1 threshold, i.e. above flux threshold of `10^7` W/m^{-2}` (**HEK SWPC list goes down to A1.1 at lest**)
2. all 4 flux values monotonically increase
3. the fourth flux value is greater than 1.4 times the first value in the sequence of 4 data points.
4. The event ends when the flux, during the decaying phase, drops below half of the peak flux.

Initially implemented basic version based on based on the above rules but found poor match to events reported in the HEK. These rules are not sufficient to implement a full algotrytm e.g. temporary bump/dips so tired to add some more condition to improve agreement with the HEK SWPC

Open questions:
* Is the "GOES X-ray flare" list available anywhere else (the modern GOES-R have a list product but that's different as far as I can see)?
* Is the HEC SWPC list the "GOES X-ray flare list" or altered improved/different?
* Look more into extra and missed events to see if can work how can improve from visual inspection both groups include non-flares and flares 😞 

## AI Assistance Disclosure

AI tools were used for:
- [x ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x ] Test/benchmark generation
- [x ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
